### PR TITLE
Moved ember-getowner-polyfill from devDependencies to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "ember-data": "^2.6.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-welcome-page": "^1.0.1",
@@ -89,7 +88,8 @@
     "browser scroll"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-getowner-polyfill": "1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Moved ember-getowner-polyfill from devDependencies to dependencies.

Closes #34 
