### PR TITLE
Align with Ember's HistoryLocation router

### DIFF
--- a/addon/locations/router-scroll.js
+++ b/addon/locations/router-scroll.js
@@ -1,24 +1,29 @@
 import Ember from 'ember';
 
+function _uuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r, v;
+    r = Math.random() * 16 | 0;
+    v = c === 'x' ? r : r & 3 | 8;
+    return v.toString(16);
+  });
+}
+
 const {
   get,
   HistoryLocation,
 } = Ember;
 
 export default HistoryLocation.extend({
-  init(...args) {
-    this._super(...args);
-    this.stateCounter = 0;
-  },
   pushState(path) {
-    const id = `${this.stateCounter++}`;
-    const state = { path, id };
+    const uuid = _uuid();
+    const state = { path, uuid };
     get(this, 'history').pushState(state, null, path);
     this._previousURL = this.getURL(); // eslint-disable-line no-underscore-dangle
   },
   replaceState(path) {
-    const id = `${this.stateCounter++}`;
-    const state = { path, id };
+    const uuid = _uuid();
+    const state = { path, uuid };
     get(this, 'history').replaceState(state, null, path);
     this._previousURL = this.getURL(); // eslint-disable-line no-underscore-dangle
   },

--- a/addon/services/router-scroll.js
+++ b/addon/services/router-scroll.js
@@ -26,11 +26,11 @@ export default Service.extend({
   },
 
   position: computed(function position() {
-    const scrollMap = get(this, 'scrollMap');
-    const stateId = get(window, 'history.state.id');
+    let scrollMap = get(this, 'scrollMap');
+    let stateUuid = get(window, 'history.state.uuid');
 
-    set(this, 'key', stateId);
-    const key = get(this, 'key') || '-1';
+    set(this, 'key', stateUuid);
+    let key = getWithDefault(this, 'key', '-1');
 
     return getWithDefault(scrollMap, key, { x: 0, y: 0 });
   }).volatile(),

--- a/tests/unit/services/router-scroll-test.js
+++ b/tests/unit/services/router-scroll-test.js
@@ -34,10 +34,10 @@ test('updating will not set `scrollMap` to the current scroll position if `key` 
   assert.deepEqual(get(service, 'scrollMap'), { });
 });
 
-test('computing the position for an existing state id return the coords', function(assert) {
+test('computing the position for an existing state uuid return the coords', function(assert) {
   let service = this.subject();
   let state = window.history.state;
-  window.history.replaceState({id: '123'}, null);
+  window.history.replaceState({uuid: '123'}, null);
 
   let expected = { x: 1, y: 1 };
   set(service, 'scrollMap.123', expected);
@@ -48,7 +48,7 @@ test('computing the position for an existing state id return the coords', functi
 test('computing the position for a state without a cached scroll position returns default', function(assert) {
   let service = this.subject();
   let state = window.history.state;
-  window.history.replaceState({id: '123'}, null);
+  window.history.replaceState({uuid: '123'}, null);
 
   let expected = { x: 0, y: 0 };
   assert.deepEqual(get(service, 'position'), expected);


### PR DESCRIPTION
Now that https://github.com/emberjs/ember.js/pull/14011 has landed
it would be best to align this library with the new implementation in
anticipation of deprecating the RouterScrollRouter for Ember 2.13 and
eventually removing it in Ember 3.0.