### PR TITLE
[RFC] User Ember.set to set previousURL

### DIFF
--- a/addon/locations/router-scroll.js
+++ b/addon/locations/router-scroll.js
@@ -8,6 +8,7 @@ const uuid = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) =
 
 const {
   get,
+  set,
   HistoryLocation,
 } = Ember;
 
@@ -15,11 +16,11 @@ export default HistoryLocation.extend({
   pushState(path) {
     const state = { path, uuid: uuid() };
     get(this, 'history').pushState(state, null, path);
-    this.previousURL = this.getURL();
+    set(this, 'previousURL', this.getURL());
   },
   replaceState(path) {
     const state = { path, uuid: uuid() };
     get(this, 'history').replaceState(state, null, path);
-    this.previousURL = this.getURL();
+    set(this, 'previousURL', this.getURL());
   },
 });


### PR DESCRIPTION
## Why
Creating and clicking the following link `<a href="/some-page"></a>` threw the following error.

`You must use Ember.set() to set the 'previousURL' property (of <project-name@location:router-scroll::ember369>) to '/category/homewares/home-accessories?p=3'.`

This PR uses Ember.set to fix the error.