### PR TITLE
Schedule window.scrollTo() to after content paint by using ember-app-scheduler

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -5,10 +5,10 @@ const {
   computed,
   get,
   inject,
-  run: { next },
 } = Ember;
 
 export default Ember.Mixin.create({
+  scheduler: inject.service('scheduler'),
   service: inject.service('router-scroll'),
 
   isFastBoot: computed(function() {
@@ -26,7 +26,9 @@ export default Ember.Mixin.create({
 
 		if (get(this, 'isFastBoot')) { return; }
 
-    next(() => this.updateScrollPosition(transitions));
+    this.get('scheduler').scheduleWork('afterContentPaint', () => {
+      this.updateScrollPosition(transitions);
+    });
   },
 
   updateScrollPosition(transitions) {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.5.6",
+    "ember-app-scheduler": "0.0.5",
     "ember-cli": "^2.12.1",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-dependency-checker": "^1.4.0",

--- a/tests/unit/mixins/router-scroll-test.js
+++ b/tests/unit/mixins/router-scroll-test.js
@@ -4,6 +4,14 @@ import { module, test } from 'qunit';
 
 module('mixin:router-scroll');
 
+function getSchedulerMock() {
+  return {
+    scheduleWork: ((eventName, callback) => {
+      callback();
+    }),
+  };
+}
+
 test('when the application is FastBooted', (assert) => {
   assert.expect(1);
 
@@ -11,6 +19,7 @@ test('when the application is FastBooted', (assert) => {
   const RouterScrollObject = Ember.Object.extend(RouterScroll);
   const subject = RouterScrollObject.create({
     isFastBoot: true,
+    scheduler: getSchedulerMock(),
     updateScrollPosition() {
       assert.notOk(true, 'it should not call updateScrollPosition.');
       done();
@@ -33,6 +42,7 @@ test('when the application is not FastBooted', (assert) => {
   const RouterScrollObject = Ember.Object.extend(RouterScroll);
   const subject = RouterScrollObject.create({
     isFastBoot: false,
+    scheduler: getSchedulerMock(),
     updateScrollPosition() {
       assert.ok(true, 'it should call updateScrollPosition.');
       done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,6 +2111,12 @@ ember-ajax@^2.5.6:
   dependencies:
     ember-cli-babel "^5.1.5"
 
+ember-app-scheduler@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/ember-app-scheduler/-/ember-app-scheduler-0.0.5.tgz#d9228207e169c60d1d6546943e51fcd6a1554b90"
+  dependencies:
+    ember-cli-babel "^5.1.7"
+
 ember-cli-app-version@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-app-version/-/ember-cli-app-version-3.0.0.tgz#d67a33aeec7bd03187fbe72c5663dadec4c3368a"


### PR DESCRIPTION
Currently the `window.scrollTo()` is sometimes called too early, before the content at the target scroll position is even rendered. This PR fixes this issue by using the `ember-app-scheduler` addon (https://github.com/sreedhar7/ember-app-scheduler) to wait until the page content is rendered before doing the scrolling.

This should also fix the jitter issue described in https://github.com/dollarshaveclub/ember-router-scroll/issues/17, as `ember-app-scheduler` uses a combination of `afterRender` queue and `window.requestAnimationFrame`.