### PR TITLE
testem: Use headless Chrome by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
-sudo: required
+sudo: false
 dist: trusty
+
 language: node_js
 node_js:
   - "6"
@@ -20,15 +21,9 @@ cache:
   yarn: true
 
 addons:
-  apt:
-    sources:
-    - google-chrome
-    packages:
-    - google-chrome-stable
+  chrome: stable
 
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
   - yarn global add bower

--- a/testem.js
+++ b/testem.js
@@ -4,37 +4,17 @@ module.exports = {
   "test_page": "tests/index.html?hidepassed&nolint",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
-  ],
-  "launch_in_dev": [
-    "PhantomJS",
     "Chrome"
   ],
-  launch_in_ci: [
-    'Chrome Custom',
+  "launch_in_dev": [
+    "Chrome"
   ],
-  launch_in_dev: [
-    'Chrome Custom',
-  ],
-  launchers: {
-    'Chrome Custom': {
-      exe: [
-        'google-chrome',
-        '~/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-      ],
-      args: [
-        '--user-data-dir=/tmp/testem.chrome.custom',
-        '--no-default-browser-check',
-        '--no-first-run',
-        '--ignore-certificate-errors',
-        '--test-type',
-        '--disable-extensions',
-        '--disable-web-security',
-        '--disable-renderer-backgrounding',
-        '--disable-background-timer-throttling',
-      ],
-      protocol: 'browser',
-    },
+  browser_args: {
+    Chrome: [
+      '--disable-gpu',
+      '--headless',
+      '--remote-debugging-port=9222',
+      '--window-size=1440,900'
+    ]
   },
 };


### PR DESCRIPTION
This should also speed up CI test times since we can use the containerized infrastructure of TravisCI