### PR TITLE
Update "ember-getowner-polyfill" to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "ember-app-scheduler": "0.0.5",
     "ember-cli-babel": "^6.6.0",
-    "ember-getowner-polyfill": "^1.2.3"
+    "ember-getowner-polyfill": "^2.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,7 +2035,7 @@ ember-app-scheduler@0.0.5:
   dependencies:
     ember-cli-babel "^5.1.7"
 
-ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
+ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.7:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -2352,11 +2352,10 @@ ember-factory-for-polyfill@^1.1.0:
     ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.2.0"
 
-ember-getowner-polyfill@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.3.tgz#ea70f4a48b1c05b91056371d1878bbafe018222e"
+ember-getowner-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.0.1.tgz#9bfe2b4d527ed174e76fef2c8f30937d77cb66fb"
   dependencies:
-    ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
 


### PR DESCRIPTION
This removes the nested dependency to `ember-cli-babel@5`