### PR TITLE
Fix edge cases for URLs with anchors

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -29,12 +29,12 @@ export default Mixin.create({
 
   updateScrollPosition(transitions) {
     const lastTransition = transitions[transitions.length - 1];
-
     const url =  get(lastTransition, 'handler.router.currentURL');
-    
+    const hashElement = document.getElementById(url.split('#').pop());
+
     let scrollPosition;
-    if(url && url.indexOf('#') > -1) {
-      const hashElement = document.getElementById(url.split('#').pop());
+
+    if(url && url.indexOf('#') > -1 && hashElement) {
       scrollPosition = { x: hashElement.offsetLeft, y: hashElement.offsetTop };
     } else {
       scrollPosition = get(this, 'service.position');

--- a/tests/unit/mixins/router-scroll-test.js
+++ b/tests/unit/mixins/router-scroll-test.js
@@ -127,6 +127,55 @@ test('Update Scroll Position: URL is an anchor', (assert) => {
   });
 });
 
+test('Update Scroll Position: URL has nothing after an anchor', (assert) => {
+  assert.expect(1);
+  const done = assert.async();
+
+  window.scrollTo = (x, y) =>
+    assert.ok(x === 1 && y === 2, 'Scroll to called with correct offsets');
+
+  const RouterScrollObject = EmberObject.extend(RouterScroll);
+  const subject = RouterScrollObject.create({
+    isFastBoot: false,
+    scheduler: getSchedulerMock(),
+    service: {
+      position: { x: 1, y: 2 },
+      scrollElement: 'window',
+    },
+  });
+
+  run(() => {
+    subject.didTransition(getTransitionsMock('Hello/#'));
+    done();
+  });
+});
+
+test('Update Scroll Position: URL has nonexistent element after anchor', (assert) => {
+  assert.expect(1);
+  const done = assert.async();
+
+  const elem = document.createElement('div');
+  elem.id = 'World';
+  document.body.insertBefore(elem, null);
+  window.scrollTo = (x, y) =>
+    assert.ok(x === 1 && y === 2, 'Scroll to called with correct offsets');
+
+  const RouterScrollObject = EmberObject.extend(RouterScroll);
+  const subject = RouterScrollObject.create({
+    isFastBoot: false,
+    scheduler: getSchedulerMock(),
+    service: {
+      position: { x: 1, y: 2 },
+      scrollElement: 'window',
+    },
+  });
+
+  run(() => {
+    subject.didTransition(getTransitionsMock('Hello/#Bar'));
+    done();
+  });
+});
+
 test('Update Scroll Position: Scroll Position is set by service', (assert) => {
   assert.expect(1);
   const done = assert.async();


### PR DESCRIPTION
Fixes #88, handles both nothing after the anchor and IDs that don't match any elements in the page.