### PR TITLE
Don't call update when running in fastboot.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -14,6 +14,9 @@ export default Mixin.create({
 
   willTransition(...args) {
     this._super(...args);
+    
+		if (get(this, 'isFastBoot')) { return; }
+
     get(this, 'service').update();
   },
 


### PR DESCRIPTION
When running in fastboot with a scrollElement there is no document object, so the
update function throws an error.