### PR TITLE
Fix bug for older versions of Ember + add LTS versions to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ node_js:
 
 env:
   - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=ember-lts-2.12
+  - EMBER_TRY_SCENARIO=ember-lts-2.16
+  - EMBER_TRY_SCENARIO=ember-lts-2.18
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/addon/index.js
+++ b/addon/index.js
@@ -14,7 +14,7 @@ export default Mixin.create({
 
   willTransition(...args) {
     this._super(...args);
-    
+
 		if (get(this, 'isFastBoot')) { return; }
 
     get(this, 'service').update();
@@ -32,8 +32,8 @@ export default Mixin.create({
 
   updateScrollPosition(transitions) {
     const lastTransition = transitions[transitions.length - 1];
-    const url =  get(lastTransition, 'handler.router.currentURL');
-    const hashElement = document.getElementById(url.split('#').pop());
+    const url = get(lastTransition, 'handler.router.currentURL');
+    const hashElement = url ? document.getElementById(url.split('#').pop()) : null;
 
     let scrollPosition;
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,6 +8,46 @@ module.exports = {
       }
     },
     {
+      name: 'ember-lts-2.8',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-8'
+        },
+        resolutions: {
+          'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.12',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.12.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.16',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.16.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.18',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.18.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  env: {
+    embertest: true
+  },
+  rules: {
+    "import/no-extraneous-dependencies": 1,
+    "prefer-arrow-callback": 1,
+    "space-before-function-paren": 1
+  }
+};

--- a/tests/acceptance/basic-functionality-test.js
+++ b/tests/acceptance/basic-functionality-test.js
@@ -1,0 +1,14 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | basic functionality');
+
+test('The application should work when loading a page and clicking a link', function(assert) {
+  visit('/');
+
+  click('a[href="/next-page"]');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/next-page');
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,8 @@
 import EmberRouter from '@ember/routing/router';
+import RouterScroll from 'ember-router-scroll';
 import config from './config/environment';
 
-const Router = EmberRouter.extend({
+const Router = EmberRouter.extend(RouterScroll, {
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -5,7 +5,8 @@ module.exports = function(environment) {
     modulePrefix: 'dummy',
     environment: environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'router-scroll',
+    historySupportMiddleware: true,
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -40,7 +41,6 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.locationType = 'hash';
     ENV.rootURL = '/ember-router-scroll/';
 
   }


### PR DESCRIPTION
There's a bug for older versions of Ember where this addon breaks (calling split on undefined url: https://github.com/dollarshaveclub/ember-router-scroll/blob/master/addon/index.js#L36). This PR fixes that bug and adds old versions of Ember to the travis matrix.

The unit tests for this part of the code base rely on mocking, so adding Ember 2.12 to travis alone would not have caught this. To find these errors I've added router-scroll to the dummy app as well as a basic acceptance test that visits a page and clicks a link. If this test passes we know the router mixin isn't throwing errors.

