### PR TITLE
afterFirstRoutePaint instead of afterContentPaint

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -25,7 +25,7 @@ export default Mixin.create({
 
 		if (get(this, 'isFastBoot')) { return; }
 
-    this.get('scheduler').scheduleWork('afterContentPaint', () => {
+    this.get('scheduler').scheduleWork('afterFirstRoutePaint', () => {
       this.updateScrollPosition(transitions);
     });
   },


### PR DESCRIPTION
This change simply puts the scrollTop functionality one frame before it currently runs (which `afterContentPaint` is two frames after running scheduleWork in didTransition).

I currently see jitter as the DOM elements of the `next` route are showing before `scrollTop` happens.  Visually, this reduces the time the `next` route content is seen before scrollTop happens; however, perhaps more work can be done to tighten this loop.

Also, I might be missing some context, but what is the reason we want to scrollTop __after__ the content has painted?  I'm currently seeing that without the `scheduleWork` functionality, visually the app is better b/w transitions w/ and w/o `fetch/xhrs`...

Ref #57 #17 