### PR TITLE
Consider all query params in parent routes

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -60,7 +60,7 @@ export default Mixin.create({
     }
     const scrollElement = get(this, 'service.scrollElement');
 
-    const preserveScrollPosition = get(lastTransition, 'handler.controller.preserveScrollPosition');
+    const preserveScrollPosition = transitions.some((transition) => get(transition, 'handler.controller.preserveScrollPosition'));
 
     if (!preserveScrollPosition) {
       if ('window' === scrollElement) {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-app-scheduler": "^0.2.0",
+    "ember-app-scheduler": "kyleshay/ember-app-scheduler#64a0c91d8866b356439bb2d3068029ac59490090",
     "ember-cli-babel": "^6.6.0",
     "ember-getowner-polyfill": "^2.0.1"
   },


### PR DESCRIPTION
Currently only the most recent transition is examined to determine whether to preserve the scroll position. This means that any parent route query parameters are not being respected. This works fine for isolated pages, like the tab example, but does not work when query params exist on the `application` route, for example.

In my case I dynamically set query parameters on the `application` route to show/hide modals. I would expect that when I set `preserveScrollPosition=true` on the `application` controller that even though I'm on a deeply nested sub-route it would be respected. Currently this is not the case.

This PR updates the line that examines only the last transition so that it checks all transitions involved to see if any of them have the parameter set.