### PR TITLE
delayScrollTop config + schedule in render queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 
 > Scroll to page top on transition, like a non-SPA website. An alternative scroll behavior for Ember applications.
 
+## Installation
+
+```
+ember install ember-router-scroll
+```
+
+### Options
+You can specify the id of an element for which the scroll position is saved and set. Default is `window` for using the scroll position of the whole viewport. You can pass an options object in your application's `config/environment.js` file.
+
+```javascript
+ENV['routerScroll'] = {
+  scrollElement: '#mainScrollElement'
+};
+
+Moreover, if your route breaks up render into multiple phases, you may need to delay scrollTop functionality until after the First Meaningful Paint using `delayScrollTop: true` in your config.  This `delayScrollTop` defaults to `false`.
+
+```javascript
+ENV['routerScroll'] = {
+  delayScrollTop: true
+};
+```
+
 ## A working example
 See [demo](https://dollarshaveclub.github.io/router-scroll-demo/) made by [Jon Chua](https://github.com/Chuabacca/).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ENV['routerScroll'] = {
   scrollElement: '#mainScrollElement'
 };
 
-Moreover, if your route breaks up render into multiple phases, you may need to delay scrollTop functionality until after the First Meaningful Paint using `delayScrollTop: true` in your config.  This `delayScrollTop` defaults to `false`.
+Moreover, if your route breaks up render into multiple phases, you may need to delay scrollTop functionality until after the First Meaningful Paint using `delayScrollTop: true` in your config.  `delayScrollTop` defaults to `false`.
 
 ```javascript
 ENV['routerScroll'] = {

--- a/addon/services/router-scroll.js
+++ b/addon/services/router-scroll.js
@@ -11,6 +11,7 @@ export default Service.extend({
   }),
 
   scrollElement: 'window',
+  delayScrollTop: false,
 
   init(...args) {
     this._super(...args);
@@ -65,6 +66,11 @@ export default Service.extend({
 
       if ('string' === typeOf(scrollElement)) {
         set(this, 'scrollElement', scrollElement);
+      }
+
+      const delayScrollTop = config.routerScroll.delayScrollTop;
+      if (delayScrollTop === true) {
+        set(this, 'delayScrollTop', true);
       }
     }
   }

--- a/tests/unit/mixins/router-scroll-test.js
+++ b/tests/unit/mixins/router-scroll-test.js
@@ -247,8 +247,8 @@ module('mixin:router-scroll', function(hooks) {
     run(() => {
       subject.didTransition(getTransitionsMock('Hello/World'));
       next(() => {
-        done()
-      })
-    })
-  })
-})
+        done();
+      });
+    });
+  });
+});

--- a/tests/unit/mixins/router-scroll-test.js
+++ b/tests/unit/mixins/router-scroll-test.js
@@ -72,15 +72,15 @@ module('mixin:router-scroll', function(hooks) {
         delayScrollTop: false,
       },
       updateScrollPosition () {
-        assert.ok(true, 'it should call updateScrollPosition.')
-        done()
+        assert.ok(true, 'it should call updateScrollPosition.');
+        done();
       },
-    })
+    });
 
     run(() => {
-      subject.didTransition()
-    })
-  })
+      subject.didTransition();
+    });
+  });
 
   test('when the application is not FastBooted with delayScrollTop', (assert) => {
     assert.expect(1);
@@ -94,8 +94,8 @@ module('mixin:router-scroll', function(hooks) {
         delayScrollTop: true,
       },
       updateScrollPosition () {
-        assert.ok(true, 'it should call updateScrollPosition.')
-        done()
+        assert.ok(true, 'it should call updateScrollPosition.');
+        done();
       },
     });
 

--- a/tests/unit/mixins/router-scroll-test.js
+++ b/tests/unit/mixins/router-scroll-test.js
@@ -68,9 +68,34 @@ module('mixin:router-scroll', function(hooks) {
     const subject = RouterScrollObject.create({
       isFastBoot: false,
       scheduler: getSchedulerMock(),
-      updateScrollPosition() {
-        assert.ok(true, 'it should call updateScrollPosition.');
-        done();
+      service: {
+        delayScrollTop: false,
+      },
+      updateScrollPosition () {
+        assert.ok(true, 'it should call updateScrollPosition.')
+        done()
+      },
+    })
+
+    run(() => {
+      subject.didTransition()
+    })
+  })
+
+  test('when the application is not FastBooted with delayScrollTop', (assert) => {
+    assert.expect(1);
+
+    const done = assert.async();
+    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const subject = RouterScrollObject.create({
+      isFastBoot: false,
+      scheduler: getSchedulerMock(),
+      service: {
+        delayScrollTop: true,
+      },
+      updateScrollPosition () {
+        assert.ok(true, 'it should call updateScrollPosition.')
+        done()
       },
     });
 
@@ -122,22 +147,22 @@ module('mixin:router-scroll', function(hooks) {
     });
 
     run(() => {
-      subject.didTransition(getTransitionsMock('Hello/#World', false, false))
-      done()
-    })
-  })
+      subject.didTransition(getTransitionsMock('Hello/#World', false, false));
+      done();
+    });
+  });
 
   test('Ensure correct internal router intimate api is used: _router', (assert) => {
-    assert.expect(1)
-    const done = assert.async()
+    assert.expect(1);
+    const done = assert.async();
 
-    const elem = document.createElement('div')
-    elem.id = 'World'
-    document.body.insertBefore(elem, null)
+    const elem = document.createElement('div');
+    elem.id = 'World';
+    document.body.insertBefore(elem, null);
     window.scrollTo = (x, y) =>
-      assert.ok(x === elem.offsetLeft && y === elem.offsetTop, 'Scroll to called with correct offsets')
+      assert.ok(x === elem.offsetLeft && y === elem.offsetTop, 'Scroll to called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(RouterScroll)
+    const RouterScrollObject = EmberObject.extend(RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
       scheduler: getSchedulerMock(),
@@ -145,13 +170,13 @@ module('mixin:router-scroll', function(hooks) {
         position: null,
         scrollElement: 'window',
       },
-    })
+    });
 
     run(() => {
-      subject.didTransition(getTransitionsMock('Hello/#World', false, true))
-      done()
-    })
-  })
+      subject.didTransition(getTransitionsMock('Hello/#World', false, true));
+      done();
+    });
+  });
 
   test('Update Scroll Position: URL has nothing after an anchor', (assert) => {
     assert.expect(1);
@@ -222,8 +247,8 @@ module('mixin:router-scroll', function(hooks) {
     run(() => {
       subject.didTransition(getTransitionsMock('Hello/World'));
       next(() => {
-        done();
-      });
-    });
-  });
-});
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
@rwwagner90 Lmk what you think!  Previous discussions had in the links below.  Basic summary is `ember-app-scheduler` [delays](https://github.com/sreedhar7/ember-app-scheduler#ember-app-scheduler) scrollTop after first meaningful paint. 

Batching scrollTop functionality to `scheduleOnce('render')` queue removes any jump from route transitions since HistoryLocation gets batched in the sync queue.  This is also more performant visually than `next`, which was how it was done before.   If users still need this behavior to delay scrollTop, it is available through `delayScrollTop: true`.  

Ref #57 #17 
Close #96 