### PR TITLE
Restructure readme to help new users get started

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,6 @@
 
 > Scroll to page top on transition, like a non-SPA website. An alternative scroll behavior for Ember applications.
 
-## Installation
-
-```
-ember install ember-router-scroll
-```
-
-### Options
-You can specify the id of an element for which the scroll position is saved and set. Default is `window` for using the scroll position of the whole viewport. You can pass an options object in your application's `config/environment.js` file.
-
-```javascript
-ENV['routerScroll'] = {
-  scrollElement: '#mainScrollElement'
-};
-```
-
 ## A working example
 See [demo](https://dollarshaveclub.github.io/ember-router-scroll/) made by [Jon Chua](https://github.com/Chuabacca/).
 
@@ -42,7 +27,8 @@ In addition to scrolling to the top of the page on most transitions, a user woul
 
 **ember-router-scroll** makes your single page application feel more like a regular website.
 
-## Usage
+
+## Installation & Usage
 
 1. Install addon
 
@@ -82,6 +68,15 @@ In your router and controller tests, add `'service:router-scroll'` and `'service
 ```js
 //{your-app}}/tests/unit/routes/{{your-route}}.js
 needs:[ 'service:router-scroll', 'service:scheduler' ],
+```
+
+### Options
+You can specify the id of an element for which the scroll position is saved and set. Default is `window` for using the scroll position of the whole viewport. You can pass an options object in your application's `config/environment.js` file.
+
+```javascript
+ENV['routerScroll'] = {
+  scrollElement: '#mainScrollElement'
+};
 ```
 
 ## Issues with nested routes


### PR DESCRIPTION
Combines the "Installation" and "Usage" sections (now after the demo / example etc) to help new users get started with minimal frustration.  Fixes #105.

### Background
I recently discovered this wonderful addon, but thought that it wasn't working in my Ember app for some reason... until I scrolled past the examples in the readme and spotted the "Usage" section - which told me how to finish setting it up.

### Alternatives
I've put the newly-combined "Installation & Usage" section after the examples, demo and "Why use it?" sections - but it could just as well come before them (as the "Installation" section did before).