### PR TITLE
Update demo URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > Scroll to page top on transition, like a non-SPA website. An alternative scroll behavior for Ember applications.
 
 ## A working example
-See [demo](https://dollarshaveclub.github.io/ember-router-scroll/) made by [Jon Chua](https://github.com/Chuabacca/).
+See [demo](https://dollarshaveclub.github.io/router-scroll-demo/) made by [Jon Chua](https://github.com/Chuabacca/).
 
 ## A visual demo
 


### PR DESCRIPTION
Although the dummy app appears to have been fixed (by #95), this repo's Github Pages doesn't appear to have been updated.  This PR therefore updates the demo URL in the readme to point to the functioning demo app instead, though it would probably be a good idea to update the version on Github Pages for this repo at some point too.

Closes #94.