### PR TITLE
Use this.get('currentURL') in updateScrollPosition

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -28,7 +28,7 @@ export default Mixin.create({
   willTransition(...args) {
     this._super(...args);
 
-		if (get(this, 'isFastBoot')) { return; }
+    if (get(this, 'isFastBoot')) { return; }
 
     get(this, 'service').update();
   },
@@ -36,7 +36,7 @@ export default Mixin.create({
   didTransition(transitions, ...args) {
     this._super(transitions, ...args);
 
-		if (get(this, 'isFastBoot')) { return; }
+    if (get(this, 'isFastBoot')) { return; }
 
     const delayScrollTop = get(this, 'service.delayScrollTop');
 
@@ -52,16 +52,8 @@ export default Mixin.create({
   },
 
   updateScrollPosition(transitions) {
-    const lastTransition = transitions[transitions.length - 1];
-
-    let routerPath
-    if (typeof get(lastTransition, 'handler._router') !== 'undefined') {
-      routerPath = 'handler._router';
-    } else {
-      routerPath = 'handler.router';
-    }
-    const url = get(lastTransition, `${routerPath}.currentURL`);
-    const hashElement = url ? document.getElementById(url.split('#').pop()) : null;
+    const url = get(this, 'currentURL');
+    const hashElement = url ? document.getElementById(url.split('#').pop()) : null
 
     let scrollPosition;
 

--- a/tests/unit/mixins/router-scroll-test.js
+++ b/tests/unit/mixins/router-scroll-test.js
@@ -4,7 +4,7 @@ import Evented from '@ember/object/evented';
 import RouterScroll from 'ember-router-scroll';
 import { module, test } from 'qunit';
 
-let scrollTo;
+let scrollTo, subject;
 
 module('mixin:router-scroll', function(hooks) {
   hooks.beforeEach(function() {
@@ -15,16 +15,15 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = scrollTo;
   });
 
-  function getTransitionsMock (URL, isPreserveScroll, hasIntimateRouterAPI) {
+  function getTransitionsMock (URL, isPreserveScroll) {
+    subject.set('currentURL', URL || 'Hello/World');
+
     return [
       {
         handler: {
           controller: {
             preserveScrollPosition: isPreserveScroll || false,
-          },
-          [hasIntimateRouterAPI ? '_router' : 'router']: {
-            currentURL: URL || 'Hello/World',
-          },
+          }
         },
       },
     ];
@@ -35,7 +34,7 @@ module('mixin:router-scroll', function(hooks) {
 
     const done = assert.async();
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: true,
       updateScrollPosition() {
         assert.notOk(true, 'it should not call updateScrollPosition.');
@@ -57,7 +56,7 @@ module('mixin:router-scroll', function(hooks) {
 
     const done = assert.async();
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: false,
       service: {
         delayScrollTop: false,
@@ -78,7 +77,7 @@ module('mixin:router-scroll', function(hooks) {
 
     const done = assert.async();
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: false,
       service: {
         targetElement: '#myElement',
@@ -99,7 +98,7 @@ module('mixin:router-scroll', function(hooks) {
 
     const done = assert.async();
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: false,
       service: {
         delayScrollTop: true,
@@ -122,7 +121,7 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = () => assert.ok(false, 'Scroll To should not be called');
 
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: false,
       service: {
         position: null,
@@ -147,7 +146,7 @@ module('mixin:router-scroll', function(hooks) {
       assert.ok(x === elem.offsetLeft && y === elem.offsetTop, 'Scroll to called with correct offsets');
 
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: false,
       service: {
         position: null,
@@ -156,7 +155,7 @@ module('mixin:router-scroll', function(hooks) {
     });
 
     run(() => {
-      subject.didTransition(getTransitionsMock('Hello/#World', false, false));
+      subject.didTransition(getTransitionsMock('Hello/#World', false));
       done();
     });
   });
@@ -172,7 +171,7 @@ module('mixin:router-scroll', function(hooks) {
       assert.ok(x === elem.offsetLeft && y === elem.offsetTop, 'Scroll to called with correct offsets');
 
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: false,
       service: {
         position: null,
@@ -181,7 +180,7 @@ module('mixin:router-scroll', function(hooks) {
     });
 
     run(() => {
-      subject.didTransition(getTransitionsMock('Hello/#World', false, true));
+      subject.didTransition(getTransitionsMock('Hello/#World', false));
       done();
     });
   });
@@ -194,7 +193,7 @@ module('mixin:router-scroll', function(hooks) {
       assert.ok(x === 1 && y === 2, 'Scroll to called with correct offsets');
 
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: false,
       service: {
         position: { x: 1, y: 2 },
@@ -219,7 +218,7 @@ module('mixin:router-scroll', function(hooks) {
       assert.ok(x === 1 && y === 2, 'Scroll to called with correct offsets');
 
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: false,
       service: {
         position: { x: 1, y: 2 },
@@ -241,7 +240,7 @@ module('mixin:router-scroll', function(hooks) {
       assert.ok(x === 1 && y === 2, 'Scroll to was called with correct offsets');
 
     const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    const subject = RouterScrollObject.create({
+    subject = RouterScrollObject.create({
       isFastBoot: false,
       service: {
         position: { x: 1, y: 2 },


### PR DESCRIPTION
Previously we retrieved the `currentURL` from the `handler` object.  And
did so by finding the `handler`'s `router`.  Which was recently made
into an intimiate API until Ember 3.5.

To remove the deprecation we detect whether the underscored intimate API
is available and use it if it is.  Otherwise we defaulted back to using
the deprecated `router` api.

Fortunately, we know that this mixin is added to the `Router` (as per
the readme) and `currentURL` is public api on that object.  So within
our Mixin we can use `this` as the `Router` and bypass the need to
retreive it from the handler.

This change necessitated that we modify the way we mock our tests.
Previously we created a fake transition that handled how our URL needed
to behave.  In order to preserve the current test API I hoisted
`subject` up and added the `currentURL` to it directly when our
transition mock is executed.

It would be more correct for us to define the `currentURL` property on
the `RouterScrollObject` when we mixin in our RouterScroll mixin, but
modifying the instance seems just as valid for our testing purposes.