### PR TITLE
Upgrades ember-app-scheduler to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ historySupportMiddleware: true,
 This location type inherits from Ember's `HistoryLocation`.
 
 4. If using old style QUnit tests. If tests based on [RFC](https://github.com/emberjs/rfcs/pull/232), you can ignore this.
-In your router and controller tests, add `'service:router-scroll'` and `'service:scheduler'` as dependencies in the `needs: []` block:
+In your router and controller tests, add `'service:router-scroll'` as a dependency in the `needs: []` block:
 
 ```js
 //{your-app}}/tests/unit/routes/{{your-route}}.js
-needs:[ 'service:router-scroll', 'service:scheduler' ],
+needs:[ 'service:router-scroll' ],
 ```
 
 ## Issues with nested routes

--- a/addon/index.js
+++ b/addon/index.js
@@ -3,15 +3,27 @@ import { get, computed } from '@ember/object';
 import { inject } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { scheduleOnce } from '@ember/runloop';
+import { setupRouter, reset, whenRouteIdle } from 'ember-app-scheduler';
 
 export default Mixin.create({
-  scheduler: inject('scheduler'),
   service: inject('router-scroll'),
 
   isFastBoot: computed(function() {
     const fastboot = getOwner(this).lookup('service:fastboot');
     return fastboot ? fastboot.get('isFastBoot') : false;
   }),
+
+  init() {
+    this._super(...arguments);
+
+    setupRouter(this);
+  },
+
+  destroy() {
+    reset();
+
+    this._super(...arguments);
+  },
 
   willTransition(...args) {
     this._super(...args);
@@ -33,7 +45,7 @@ export default Mixin.create({
     } else {
       // as described in ember-app-scheduler, this addon can be used to delay rendering until after First Meaningful Paint.
       // If you loading your routes progressively, this may be a good option to delay scrollTop until the remaining DOM elements are painted.
-      this.get('scheduler').scheduleWork('afterContentPaint', () => {
+      whenRouteIdle().then(() => {
         this.updateScrollPosition(transitions);
       });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-router-scroll",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Scroll to top with preserved browser history scroll position",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-app-scheduler": "^0.2.2",
+    "ember-app-scheduler": "^1.0.1",
     "ember-cli-babel": "^6.6.0",
     "ember-getowner-polyfill": "^2.0.1"
   },

--- a/tests/unit/mixins/router-scroll-test.js
+++ b/tests/unit/mixins/router-scroll-test.js
@@ -1,5 +1,6 @@
 import { run, next } from '@ember/runloop';
 import EmberObject from '@ember/object';
+import Evented from '@ember/object/evented';
 import RouterScroll from 'ember-router-scroll';
 import { module, test } from 'qunit';
 
@@ -13,14 +14,6 @@ module('mixin:router-scroll', function(hooks) {
   hooks.afterEach(function() {
     window.scrollTo = scrollTo;
   });
-
-  function getSchedulerMock() {
-    return {
-      scheduleWork: (eventName, callback) => {
-        callback();
-      },
-    };
-  }
 
   function getTransitionsMock (URL, isPreserveScroll, hasIntimateRouterAPI) {
     return [
@@ -41,10 +34,9 @@ module('mixin:router-scroll', function(hooks) {
     assert.expect(1);
 
     const done = assert.async();
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: true,
-      scheduler: getSchedulerMock(),
       updateScrollPosition() {
         assert.notOk(true, 'it should not call updateScrollPosition.');
         done();
@@ -64,10 +56,9 @@ module('mixin:router-scroll', function(hooks) {
     assert.expect(1);
 
     const done = assert.async();
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
-      scheduler: getSchedulerMock(),
       service: {
         delayScrollTop: false,
       },
@@ -86,10 +77,9 @@ module('mixin:router-scroll', function(hooks) {
     assert.expect(1);
 
     const done = assert.async();
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
-      scheduler: getSchedulerMock(),
       service: {
         targetElement: '#myElement',
       },
@@ -108,10 +98,9 @@ module('mixin:router-scroll', function(hooks) {
     assert.expect(1);
 
     const done = assert.async();
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
-      scheduler: getSchedulerMock(),
       service: {
         delayScrollTop: true,
       },
@@ -132,10 +121,9 @@ module('mixin:router-scroll', function(hooks) {
 
     window.scrollTo = () => assert.ok(false, 'Scroll To should not be called');
 
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
-      scheduler: getSchedulerMock(),
       service: {
         position: null,
         scrollElement: 'window',
@@ -158,10 +146,9 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = (x, y) =>
       assert.ok(x === elem.offsetLeft && y === elem.offsetTop, 'Scroll to called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
-      scheduler: getSchedulerMock(),
       service: {
         position: null,
         scrollElement: 'window',
@@ -184,10 +171,9 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = (x, y) =>
       assert.ok(x === elem.offsetLeft && y === elem.offsetTop, 'Scroll to called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
-      scheduler: getSchedulerMock(),
       service: {
         position: null,
         scrollElement: 'window',
@@ -207,10 +193,9 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = (x, y) =>
       assert.ok(x === 1 && y === 2, 'Scroll to called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
-      scheduler: getSchedulerMock(),
       service: {
         position: { x: 1, y: 2 },
         scrollElement: 'window',
@@ -233,10 +218,9 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = (x, y) =>
       assert.ok(x === 1 && y === 2, 'Scroll to called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
-      scheduler: getSchedulerMock(),
       service: {
         position: { x: 1, y: 2 },
         scrollElement: 'window',
@@ -256,10 +240,9 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = (x, y) =>
       assert.ok(x === 1 && y === 2, 'Scroll to was called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(RouterScroll);
+    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
     const subject = RouterScrollObject.create({
       isFastBoot: false,
-      scheduler: getSchedulerMock(),
       service: {
         position: { x: 1, y: 2 },
         scrollElement: 'window',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,9 +1966,9 @@ electron-to-chromium@^1.3.30:
   version "1.3.42"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz#95c33bf01d0cc405556aec899fe61fd4d76ea0f9"
 
-ember-app-scheduler@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/ember-app-scheduler/-/ember-app-scheduler-0.2.2.tgz#e4a66275d1789d1b054815ee230c6f759b4b75eb"
+ember-app-scheduler@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ember-app-scheduler/-/ember-app-scheduler-1.0.1.tgz#cc25e79d139525e440f2b26bcf8fdd60a3899878"
   dependencies:
     ember-cli-babel "^6.3.0"
 


### PR DESCRIPTION
The first major release of ember-app-scheduler is out, and includes a rewrite of the existing API. This PR bumps the version to the latest, and upgrades the API usage to the new API.

This PR supersedes #129 and #138 