### PR TITLE
Traverse transition tree to find preserveScrollPosition

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -70,7 +70,8 @@ export default Mixin.create({
     } else {
       scrollPosition = get(this, 'service.position');
     }
-    const preserveScrollPosition = get(lastTransition, 'handler.controller.preserveScrollPosition');
+
+    const preserveScrollPosition = transitions.some((transition) => get(transition, 'handler.controller.preserveScrollPosition'));
 
     if (!preserveScrollPosition) {
       const scrollElement = get(this, 'service.scrollElement');


### PR DESCRIPTION
Ensures preserveScrollPosition set on any parent transition will actually preserveScrollPosition.

This is a remake of #97. 

Credit goes to @hbrysiewicz.

I was going to add some notes to the readme, but I actually think this is what someone would have thought when reading the readme (as I just read it for the first time a few hrs ago and thought this lib worked different.)

Closes #97 