### PR TITLE
Ember 3.9 deprecation fixes

### DIFF
--- a/addon/services/router-scroll.js
+++ b/addon/services/router-scroll.js
@@ -4,7 +4,7 @@ import { typeOf } from '@ember/utils';
 import { assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
 
-export default Service.extend({
+const RouterScroll = Service.extend({
   isFastBoot: computed(function() {
     const fastboot = getOwner(this).lookup('service:fastboot');
     return fastboot ? fastboot.get('isFastBoot') : false;
@@ -66,16 +66,6 @@ export default Service.extend({
     }
   },
 
-  position: computed(function position() {
-    const scrollMap = get(this, 'scrollMap');
-    const stateUuid = get(window, 'history.state.uuid');
-
-    set(this, 'key', stateUuid); // eslint-disable-line ember/no-side-effects
-    const key = getWithDefault(this, 'key', '-1');
-
-    return getWithDefault(scrollMap, key, scrollMap.default);
-  }).volatile(),
-
   _loadConfig() {
     const config = getOwner(this).resolveRegistration('config:environment');
 
@@ -100,3 +90,17 @@ export default Service.extend({
     }
   }
 });
+
+Object.defineProperty(RouterScroll.prototype, 'position', {
+  get() {
+    const scrollMap = get(this, 'scrollMap');
+    const stateUuid = get(window, 'history.state.uuid');
+
+    set(this, 'key', stateUuid);
+    const key = getWithDefault(this, 'key', '-1');
+
+    return getWithDefault(scrollMap, key, scrollMap.default);
+  }
+});
+
+export default RouterScroll;

--- a/tests/unit/mixins/router-scroll-test.js
+++ b/tests/unit/mixins/router-scroll-test.js
@@ -3,11 +3,14 @@ import EmberObject from '@ember/object';
 import Evented from '@ember/object/evented';
 import RouterScroll from 'ember-router-scroll';
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 import { gte } from 'ember-compatibility-helpers';
 
 let scrollTo, subject;
 
 module('mixin:router-scroll', function(hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function() {
     scrollTo = window.scrollTo;
   });
@@ -30,18 +33,19 @@ module('mixin:router-scroll', function(hooks) {
     return gte('3.6.0-beta.1') ? transition : [transition];
   }
 
-  test('when the application is FastBooted', (assert) => {
+  test('when the application is FastBooted', function(assert) {
     assert.expect(1);
-
     const done = assert.async();
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: true,
+
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: true }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll, {
       updateScrollPosition() {
         assert.notOk(true, 'it should not call updateScrollPosition.');
         done();
       }
-    });
+    }));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {
@@ -56,21 +60,20 @@ module('mixin:router-scroll', function(hooks) {
     });
   });
 
-  test('when the application is not FastBooted', (assert) => {
+  test('when the application is not FastBooted', function(assert) {
     assert.expect(1);
-
     const done = assert.async();
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: false,
-      service: {
-        delayScrollTop: false
-      },
+
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register('service:router-scroll', EmberObject.extend({ delayScrollTop: false }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll, {
       updateScrollPosition() {
         assert.ok(true, 'it should call updateScrollPosition.');
         done();
       }
-    });
+    }));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {
@@ -81,21 +84,20 @@ module('mixin:router-scroll', function(hooks) {
     });
   });
 
-  test('when the application is not FastBooted with targetElement', (assert) => {
+  test('when the application is not FastBooted with targetElement', function(assert) {
     assert.expect(1);
-
     const done = assert.async();
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: false,
-      service: {
-        targetElement: '#myElement'
-      },
+
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register('service:router-scroll', EmberObject.extend({ targetElement: '#myElement' }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll, {
       updateScrollPosition() {
         assert.ok(true, 'it should call updateScrollPosition.');
         done();
       }
-    });
+    }));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {
@@ -106,21 +108,20 @@ module('mixin:router-scroll', function(hooks) {
     });
   });
 
-  test('when the application is not FastBooted with delayScrollTop', (assert) => {
+  test('when the application is not FastBooted with delayScrollTop', function(assert) {
     assert.expect(1);
-
     const done = assert.async();
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: false,
-      service: {
-        delayScrollTop: true
-      },
+
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register('service:router-scroll', EmberObject.extend({ delayScrollTop: true }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll, {
       updateScrollPosition() {
         assert.ok(true, 'it should call updateScrollPosition.');
         done();
       }
-    });
+    }));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {
@@ -131,20 +132,20 @@ module('mixin:router-scroll', function(hooks) {
     });
   });
 
-  test('Update Scroll Position: Position is preserved', (assert) => {
+  test('Update Scroll Position: Position is preserved', function(assert) {
     assert.expect(0);
     const done = assert.async();
 
     window.scrollTo = () => assert.ok(false, 'Scroll To should not be called');
 
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: false,
-      service: {
-        position: null,
-        scrollElement: 'window'
-      }
-    });
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register('service:router-scroll', EmberObject.extend({
+      position: null,
+      scrollElement: 'window'
+    }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {
@@ -156,7 +157,7 @@ module('mixin:router-scroll', function(hooks) {
     });
   });
 
-  test('Update Scroll Position: URL is an anchor', (assert) => {
+  test('Update Scroll Position: URL is an anchor', function(assert) {
     assert.expect(1);
     const done = assert.async();
 
@@ -166,14 +167,14 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = (x, y) =>
       assert.ok(x === elem.offsetLeft && y === elem.offsetTop, 'Scroll to called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: false,
-      service: {
-        position: null,
-        scrollElement: 'window'
-      }
-    });
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register('service:router-scroll', EmberObject.extend({
+      position: null,
+      scrollElement: 'window'
+    }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {
@@ -185,7 +186,7 @@ module('mixin:router-scroll', function(hooks) {
     });
   });
 
-  test('Ensure correct internal router intimate api is used: _router', (assert) => {
+  test('Ensure correct internal router intimate api is used: _router', function(assert) {
     assert.expect(1);
     const done = assert.async();
 
@@ -195,14 +196,14 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = (x, y) =>
       assert.ok(x === elem.offsetLeft && y === elem.offsetTop, 'Scroll to called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: false,
-      service: {
-        position: null,
-        scrollElement: 'window'
-      }
-    });
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register('service:router-scroll', EmberObject.extend({
+      position: null,
+      scrollElement: 'window'
+    }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {
@@ -214,21 +215,23 @@ module('mixin:router-scroll', function(hooks) {
     });
   });
 
-  test('Update Scroll Position: URL has nothing after an anchor', (assert) => {
+  test('Update Scroll Position: URL has nothing after an anchor', function(assert) {
     assert.expect(1);
     const done = assert.async();
 
     window.scrollTo = (x, y) =>
       assert.ok(x === 1 && y === 2, 'Scroll to called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: false,
-      service: {
-        position: { x: 1, y: 2 },
-        scrollElement: 'window'
-      }
-    });
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register('service:router-scroll', EmberObject.extend({
+      get position() {
+        return { x: 1, y: 2 };
+      },
+      scrollElement: 'window'
+    }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {
@@ -240,7 +243,7 @@ module('mixin:router-scroll', function(hooks) {
     });
   });
 
-  test('Update Scroll Position: URL has nonexistent element after anchor', (assert) => {
+  test('Update Scroll Position: URL has nonexistent element after anchor', function(assert) {
     assert.expect(1);
     const done = assert.async();
 
@@ -250,14 +253,16 @@ module('mixin:router-scroll', function(hooks) {
     window.scrollTo = (x, y) =>
       assert.ok(x === 1 && y === 2, 'Scroll to called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: false,
-      service: {
-        position: { x: 1, y: 2 },
-        scrollElement: 'window'
-      }
-    });
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register('service:router-scroll', EmberObject.extend({
+      get position() {
+        return { x: 1, y: 2 };
+      },
+      scrollElement: 'window'
+    }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {
@@ -269,21 +274,23 @@ module('mixin:router-scroll', function(hooks) {
     });
   });
 
-  test('Update Scroll Position: Scroll Position is set by service', (assert) => {
+  test('Update Scroll Position: Scroll Position is set by service', function(assert) {
     assert.expect(1);
     const done = assert.async();
 
     window.scrollTo = (x, y) =>
       assert.ok(x === 1 && y === 2, 'Scroll to was called with correct offsets');
 
-    const RouterScrollObject = EmberObject.extend(Evented, RouterScroll);
-    subject = RouterScrollObject.create({
-      isFastBoot: false,
-      service: {
-        position: { x: 1, y: 2 },
-        scrollElement: 'window'
-      }
-    });
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register('service:router-scroll', EmberObject.extend({
+      get position() {
+        return { x: 1, y: 2 };
+      },
+      scrollElement: 'window'
+    }));
+    this.owner.register('router:main', EmberObject.extend(Evented, RouterScroll));
+
+    subject = this.owner.factoryFor('router:main').create();
 
     run(() => {
       if(gte('3.6.0-beta.1')) {

--- a/tests/unit/services/router-scroll-test.js
+++ b/tests/unit/services/router-scroll-test.js
@@ -1,4 +1,4 @@
-import { set, get } from '@ember/object';
+import EmberObject, { set, get } from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -63,7 +63,8 @@ module('service:router-scroll', function(hooks) {
     otherElem.setAttribute('id', 'other-elem');
     const testing = document.querySelector('#ember-testing');
     testing.appendChild(otherElem);
-    const service = this.owner.factoryFor('service:router-scroll').create({ scrollElement: '#other-elem', isFastBoot: true });
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: true }));
+    const service = this.owner.factoryFor('service:router-scroll').create({ scrollElement: '#other-elem' });
     window.history.replaceState({ uuid: '123' }, null);
 
     let expected = { x: 0, y: 0 };
@@ -77,7 +78,8 @@ module('service:router-scroll', function(hooks) {
     otherElem.setAttribute('id', 'other-elem');
     const testing = document.querySelector('#ember-testing');
     testing.appendChild(otherElem);
-    const service = this.owner.factoryFor('service:router-scroll').create({ targetElement: '#other-elem', isFastBoot: true });
+    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: true }));
+    const service = this.owner.factoryFor('service:router-scroll').create({ targetElement: '#other-elem' });
     window.history.replaceState({ uuid: '123' }, null);
 
     let expected = { x: 0, y: 0 };


### PR DESCRIPTION
Ember 3.9 has been released (https://blog.emberjs.com/2019/04/10/ember-3-9-released.html) and it brings new deprecations, two of which affect this add-on:

* [computed-property.volatile](https://deprecations.emberjs.com/v3.x/#toc_computed-property-volatile)
* [computed-property.override](https://deprecations.emberjs.com/v3.x/#toc_computed-property-override)

This PR fixes both of them.