### PR TITLE
Upgrade eslint-plugin-ember to v10.5.7

### DIFF
--- a/addon/services/router-scroll.js
+++ b/addon/services/router-scroll.js
@@ -76,6 +76,7 @@ class RouterScroll extends Service {
     setupRouter(this.router);
   }
 
+  // eslint-disable-next-line ember/classic-decorator-hooks
   init(...args) {
     super.init(...args);
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",
     "@embroider/test-setup": "^0.36.0",
-    "babel-eslint": "^10.0.3",
+    "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.14.0",
     "ember-cli-dependency-checker": "^3.1.0",
@@ -85,7 +85,7 @@
     "ember-template-lint": "^3.10.0",
     "ember-try": "^1.0.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-ember": "^7.1.0",
+    "eslint-plugin-ember": "^10.5.7",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-qunit": "^7.0.0",
     "loader.js": "^4.7.0",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-  env: {
-    embertest: true
-  },
-  rules: {
-  }
-};

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,7 +1,7 @@
 import Application from '@ember/application';
-import Resolver from './resolver';
+import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
-import config from './config/environment';
+import config from 'dummy/config/environment';
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: ['small', 'preserveScrollPosition'],
-  small: false
-});
+export default class extends Controller {
+  queryParams = ['small', 'preserveScrollPosition'];
+  small = false;
+}

--- a/tests/dummy/app/helpers/not.js
+++ b/tests/dummy/app/helpers/not.js
@@ -1,7 +1,7 @@
 import Helper from '@ember/component/helper';
 
-export default Helper.extend({
+export default class extends Helper {
   compute([value]) {
     return !value;
   }
-});
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
 import EmberRouter from '@ember/routing/router';
-import config from './config/environment';
+import config from 'dummy/config/environment';
 
-class Router extends EmberRouter {
+export default class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 }
@@ -11,5 +11,3 @@ Router.map(function () {
   this.route('target');
   this.route('target-next-page');
 });
-
-export default Router;

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,4 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-});
+export default class extends Route {}

--- a/tests/dummy/app/routes/target-next-page.js
+++ b/tests/dummy/app/routes/target-next-page.js
@@ -1,4 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-});
+export default class extends Route {}

--- a/tests/dummy/app/routes/target.js
+++ b/tests/dummy/app/routes/target.js
@@ -1,4 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-});
+export default class extends Route {}

--- a/tests/unit/router-scroll-test.js
+++ b/tests/unit/router-scroll-test.js
@@ -47,7 +47,12 @@ module('router-scroll', function(hooks) {
     assert.expect(1);
     const done = assert.async();
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: true }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = true;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     routerScrollService.updateScrollPosition = () => {
       assert.notOk(true, 'it should not call updateScrollPosition.');
@@ -66,7 +71,12 @@ module('router-scroll', function(hooks) {
     assert.expect(1);
     const done = assert.async();
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = false;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     routerScrollService.scrollWhenIdle = false;
     routerScrollService.updateScrollPosition = () => {
@@ -82,7 +92,12 @@ module('router-scroll', function(hooks) {
     assert.expect(1);
     const done = assert.async();
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = false;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     routerScrollService.targetElement = '#myElement';
     routerScrollService.updateScrollPosition = () => {
@@ -98,7 +113,12 @@ module('router-scroll', function(hooks) {
     assert.expect(1);
     const done = assert.async();
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = false;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     routerScrollService.scrollWhenIdle = true;
     routerScrollService.updateScrollPosition = () => {
@@ -114,7 +134,12 @@ module('router-scroll', function(hooks) {
     assert.expect(1);
     const done = assert.async();
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = false;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     routerScrollService.scrollWhenAfterRender = true;
     routerScrollService.updateScrollPosition = () => {
@@ -133,7 +158,12 @@ module('router-scroll', function(hooks) {
       assert.ok(false, 'Scroll To should not be called');
     }
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = false;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     Object.defineProperty(routerScrollService, 'position', {
       get position() {
@@ -183,7 +213,12 @@ module('router-scroll', function(hooks) {
       done();
     }
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = false;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     routerScrollService.currentURL = '#World';
     Object.defineProperty(routerScrollService, 'position', {
@@ -211,7 +246,12 @@ module('router-scroll', function(hooks) {
       done();
     }
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = false;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     Object.defineProperty(routerScrollService,'position', { value: { x: 1, y: 2 } });
     routerScrollService.scrollElement = 'window';
@@ -237,7 +277,12 @@ module('router-scroll', function(hooks) {
       done();
     }
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = false;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     Object.defineProperty(routerScrollService,'position', { value: { x: 1, y: 2 } });
     routerScrollService.scrollElement = 'window';
@@ -264,7 +309,12 @@ module('router-scroll', function(hooks) {
       done();
     }
 
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: false }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = false;
+      }
+    );
     const routerScrollService = this.owner.lookup('service:router-scroll');
     Object.defineProperty(routerScrollService,'position', { value: { x: 1, y: 20 } });
     routerScrollService.scrollElement = 'window';

--- a/tests/unit/services/router-scroll-test.js
+++ b/tests/unit/services/router-scroll-test.js
@@ -1,4 +1,4 @@
-import EmberObject, { set, get } from '@ember/object';
+import EmberObject, { set } from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -14,21 +14,21 @@ module('service:router-scroll', function(hooks) {
 
   test('it inits `scrollMap` and `key`', function(assert) {
     const service = this.owner.lookup('service:router-scroll');
-    assert.deepEqual(get(service, 'scrollMap'), defaultScrollMap);
-    assert.deepEqual(get(service, 'key'), undefined);
+    assert.deepEqual(service.scrollMap, defaultScrollMap);
+    assert.deepEqual(service.key, undefined);
   });
 
   test('it inits `scrollMap` and `key` with scrollElement other than window', function(assert) {
     const service = this.owner.factoryFor('service:router-scroll').create({ scrollElement: '#other-elem' });
-    assert.deepEqual(get(service, 'scrollMap'), defaultScrollMap);
-    assert.deepEqual(get(service, 'key'), undefined);
+    assert.deepEqual(service.scrollMap, defaultScrollMap);
+    assert.deepEqual(service.key, undefined);
   });
 
   test('updating will not set `scrollMap` to the current scroll position if `key` is not yet set', function(assert) {
     const service = this.owner.lookup('service:router-scroll');
 
     service.update();
-    assert.deepEqual(get(service, 'scrollMap'), defaultScrollMap);
+    assert.deepEqual(service.scrollMap, defaultScrollMap);
   });
 
   test('updating will set `scrollMap` to the current scroll position', function(assert) {
@@ -37,7 +37,7 @@ module('service:router-scroll', function(hooks) {
     const expected = { x: window.scrollX, y: window.scrollY };
     set(service, 'key', '123');
     service.update();
-    assert.deepEqual(get(service, 'scrollMap'), { 123: expected, default: { x: 0, y: 0 } });
+    assert.deepEqual(service.scrollMap, { 123: expected, default: { x: 0, y: 0 } });
   });
 
   test('updating will not set `scrollMap` if scrollElement is defined and element is not found', function(assert) {
@@ -45,8 +45,8 @@ module('service:router-scroll', function(hooks) {
 
     service.update();
     const expected = { x: 0, y: 0 };
-    assert.deepEqual(get(service, 'position'), expected);
-    assert.deepEqual(get(service, 'scrollMap'), defaultScrollMap);
+    assert.deepEqual(service.position, expected);
+    assert.deepEqual(service.scrollMap, defaultScrollMap);
   });
 
   test('updating will not set `scrollMap` if targetElement is defined and element is not found', function(assert) {
@@ -54,8 +54,8 @@ module('service:router-scroll', function(hooks) {
 
     service.update();
     const expected = { x: 0, y: 0 };
-    assert.deepEqual(get(service, 'position'), expected);
-    assert.deepEqual(get(service, 'scrollMap'), defaultScrollMap);
+    assert.deepEqual(service.position, expected);
+    assert.deepEqual(service.scrollMap, defaultScrollMap);
   });
 
   test('updating will not set `scrollMap` if scrollElement is defined and in fastboot', function(assert) {
@@ -63,14 +63,19 @@ module('service:router-scroll', function(hooks) {
     otherElem.setAttribute('id', 'other-elem');
     const testing = document.querySelector('#ember-testing');
     testing.appendChild(otherElem);
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: true }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = true;
+      }
+    );
     const service = this.owner.factoryFor('service:router-scroll').create({ scrollElement: '#other-elem' });
     window.history.replaceState({ uuid: '123' }, null);
 
     let expected = { x: 0, y: 0 };
-    assert.deepEqual(get(service, 'position'), expected, 'position is defaulted');
+    assert.deepEqual(service.position, expected, 'position is defaulted');
     service.update();
-    assert.deepEqual(get(service, 'scrollMap'), defaultScrollMap, 'does not set scrollMap b/c in fastboot');
+    assert.deepEqual(service.scrollMap, defaultScrollMap, 'does not set scrollMap b/c in fastboot');
   });
 
   test('updating will not set `scrollMap` if targetElement is defined and in fastboot', function(assert) {
@@ -78,14 +83,19 @@ module('service:router-scroll', function(hooks) {
     otherElem.setAttribute('id', 'other-elem');
     const testing = document.querySelector('#ember-testing');
     testing.appendChild(otherElem);
-    this.owner.register('service:fastboot', EmberObject.extend({ isFastBoot: true }));
+    this.owner.register(
+      'service:fastboot',
+      class extends EmberObject {
+        isFastBoot = true;
+      }
+    );
     const service = this.owner.factoryFor('service:router-scroll').create({ targetElement: '#other-elem' });
     window.history.replaceState({ uuid: '123' }, null);
 
     let expected = { x: 0, y: 0 };
-    assert.deepEqual(get(service, 'position'), expected, 'position is defaulted');
+    assert.deepEqual(service.position, expected, 'position is defaulted');
     service.update();
-    assert.deepEqual(get(service, 'scrollMap'), defaultScrollMap, 'does not set scrollMap b/c in fastboot');
+    assert.deepEqual(service.scrollMap, defaultScrollMap, 'does not set scrollMap b/c in fastboot');
   });
 
   test('updating will set `scrollMap` if scrollElement is defined', function(assert) {
@@ -97,9 +107,9 @@ module('service:router-scroll', function(hooks) {
     window.history.replaceState({ uuid: '123' }, null);
 
     let expected = { x: 0, y: 0 };
-    assert.deepEqual(get(service, 'position'), expected, 'position is defaulted');
+    assert.deepEqual(service.position, expected, 'position is defaulted');
     service.update();
-    assert.deepEqual(get(service, 'scrollMap'), {
+    assert.deepEqual(service.scrollMap, {
       '123': expected,
       default: { x: 0, y: 0 } }, 'sets scrollMap');
   });
@@ -115,9 +125,9 @@ module('service:router-scroll', function(hooks) {
     window.history.replaceState({ uuid: '123' }, null);
 
     let expected = { x: 0, y: 0 };
-    assert.deepEqual(get(service, 'position'), expected, 'position is defaulted');
+    assert.deepEqual(service.position, expected, 'position is defaulted');
     service.update();
-    assert.deepEqual(get(service, 'scrollMap'), { '123': { x: 0, y: 100 }, default: { x: 0, y: 100 } }, 'sets scrollMap');
+    assert.deepEqual(service.scrollMap, { '123': { x: 0, y: 100 }, default: { x: 0, y: 100 } }, 'sets scrollMap');
   });
 
   test('computing the position for an existing state uuid return the coords', function(assert) {
@@ -126,7 +136,7 @@ module('service:router-scroll', function(hooks) {
 
     const expected = { x: 1, y: 1 };
     set(service, 'scrollMap.123', expected);
-    assert.deepEqual(get(service, 'position'), expected);
+    assert.deepEqual(service.position, expected);
   });
 
   test('computing the position for a state without a cached scroll position returns default', function(assert) {
@@ -135,7 +145,7 @@ module('service:router-scroll', function(hooks) {
     window.history.replaceState({ uuid: '123' }, null);
 
     const expected = { x: 0, y: 0 };
-    assert.deepEqual(get(service, 'position'), expected);
+    assert.deepEqual(service.position, expected);
     window.history.replaceState(state, null);
   });
 
@@ -143,6 +153,6 @@ module('service:router-scroll', function(hooks) {
     const service = this.owner.lookup('service:router-scroll');
 
     const expected = { x: 0, y: 0 };
-    assert.deepEqual(get(service, 'position'), expected);
+    assert.deepEqual(service.position, expected);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,7 +1889,7 @@ babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-eslint@^10.0.3:
+babel-eslint@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
   integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
@@ -4030,6 +4030,14 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+css-tree@^1.0.0-alpha.39:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
+  dependencies:
+    mdn-data "2.0.14"
+    source-map "^0.6.1"
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -4825,7 +4833,7 @@ ember-resolver@^5.3.0:
     ember-cli-version-checker "^3.1.3"
     resolve "^1.12.0"
 
-ember-rfc176-data@^0.3.1, ember-rfc176-data@^0.3.12, ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.17:
+ember-rfc176-data@^0.3.1, ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.15, ember-rfc176-data@^0.3.17:
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.17.tgz#d4fc6c33abd6ef7b3440c107a28e04417b49860a"
   integrity sha512-EVzTTKqxv9FZbEh6Ktw56YyWRAA0MijKvl7H8C06wVF+8f/cRRz3dXxa4nkwjzyVwx4rzKGuIGq77hxJAQhWWw==
@@ -5127,13 +5135,18 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-plugin-ember@^7.1.0:
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-7.13.0.tgz#a1df7794f06cdc6e1b8acfe6c59db5cf861f53dc"
-  integrity sha512-qIbw4uP0qUJoiWF4+7MTJWqwEN86RGmBNId0cwSoHoVNWtcw50R1ajYgxM1Q5FVUdoisVeSl9lKVRh5zkDFl+g==
+eslint-plugin-ember@^10.5.7:
+  version "10.5.7"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-10.5.7.tgz#132dcd139fc9e830b707910d1ee4a458b83ab9d4"
+  integrity sha512-PTnZxbexrvRgEUtiuTaRjcFIIezzNsaJLUkvOoKhmxXTZnWgSPV36PGv5ml0BOallWYAOocefjTgv9SWvlmEdw==
   dependencies:
     "@ember-data/rfc395-data" "^0.0.4"
-    ember-rfc176-data "^0.3.12"
+    css-tree "^1.0.0-alpha.39"
+    ember-rfc176-data "^0.3.15"
+    eslint-utils "^3.0.0"
+    estraverse "^5.2.0"
+    lodash.kebabcase "^4.1.1"
+    requireindex "^1.2.0"
     snake-case "^3.0.3"
 
 eslint-plugin-es@^2.0.0:
@@ -7603,6 +7616,11 @@ lodash.isarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -7830,6 +7848,11 @@ matcher-collection@^2.0.0:
   dependencies:
     "@types/minimatch" "^3.0.3"
     minimatch "^3.0.2"
+
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
 mdurl@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This is to align with latest addon blueprint and follow best Ember practices.

Most of changes changes in the dummy test app setup caused by changes in recommended rules of the plugin.