### PR TITLE
CI: Disable Ember.js v4 scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
       CI: true
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         try-scenario: [
           ember-lts-3.12,
           ember-lts-3.16,
           ember-lts-3.20,
-          ember-beta,
-          ember-canary,
+          #ember-beta,
+          #ember-canary,
           ember-default-with-jquery
         ]
     steps:


### PR DESCRIPTION
> Compiler.registerPlugin is not a function

This PR disables the Ember.js v4 scenarios for now, until we've fixed the issue with other dependencies.