### PR TITLE
Reduce Ember.get usage in RouterScroll service

### DIFF
--- a/addon/services/router-scroll.js
+++ b/addon/services/router-scroll.js
@@ -113,21 +113,21 @@ class RouterScroll extends Service {
    * @param {transition|transition[]} transition If before Ember 3.6, this will be an array of transitions, otherwise
    */
   updateScrollPosition(transition) {
-    const url = get(this, 'currentURL');
+    const url = this.currentURL;
     const hashElement = url ? document.getElementById(url.split('#').pop()) : null;
 
-    if (get(this, 'isFirstLoad')) {
+    if (this.isFirstLoad) {
       this.unsetFirstLoad();
     }
 
-    let scrollPosition = get(this, 'position');
+    let scrollPosition = this.position;
 
     if (url && url.indexOf('#') > -1 && hashElement) {
       scrollPosition = { x: hashElement.offsetLeft, y: hashElement.offsetTop };
     }
 
     // If `preserveScrollPosition` was not set on the controller, attempt fallback to `preserveScrollPosition` which was set on the router service.
-    let preserveScrollPosition = (get(transition, 'router.currentRouteInfos') || []).some((routeInfo) => get(routeInfo, 'route.controller.preserveScrollPosition')) || get(this, 'preserveScrollPosition')
+    let preserveScrollPosition = (transition.router.currentRouteInfos || []).some((routeInfo) => routeInfo.route.controller.preserveScrollPosition) || this.preserveScrollPosition
 
     if (!preserveScrollPosition) {
       const { scrollElement, targetElement } = this;
@@ -152,7 +152,7 @@ class RouterScroll extends Service {
 
   @action
   _routeWillChange() {
-    if (get(this, 'isFastBoot')) {
+    if (this.isFastBoot) {
       return;
     }
 
@@ -161,12 +161,12 @@ class RouterScroll extends Service {
 
   @action
   _routeDidChange(transition) {
-    if (get(this, 'isFastBoot')) {
+    if (this.isFastBoot) {
       return;
     }
 
-    const scrollWhenIdle = get(this, 'scrollWhenIdle');
-    const scrollWhenAfterRender = get(this, 'scrollWhenAfterRender');
+    const scrollWhenIdle = this.scrollWhenIdle;
+    const scrollWhenAfterRender = this.scrollWhenAfterRender;
 
     if (!scrollWhenIdle && !scrollWhenAfterRender) {
       // out of the option, this happens on the tightest schedule
@@ -186,14 +186,14 @@ class RouterScroll extends Service {
   }
 
   update() {
-    if (get(this, 'isFastBoot') || get(this, 'isFirstLoad')) {
+    if (this.isFastBoot || this.isFirstLoad) {
       return;
     }
 
-    const scrollElement = get(this, 'scrollElement');
-    const targetElement = get(this, 'targetElement');
-    const scrollMap = get(this, 'scrollMap');
-    const key = get(this, 'key');
+    const scrollElement = this.scrollElement;
+    const targetElement = this.targetElement;
+    const scrollMap = this.scrollMap;
+    const key = this.key;
     let x;
     let y;
 
@@ -261,11 +261,11 @@ class RouterScroll extends Service {
 Object.defineProperty(RouterScroll.prototype, 'position', {
   configurable: true,
   get() {
-    const scrollMap = get(this, 'scrollMap');
-    const stateUuid = get(window, 'history.state.uuid');
+    const scrollMap = this.scrollMap;
+    const stateUuid = window.history.state?.uuid;
 
     set(this, 'key', stateUuid);
-    const key = get(this, 'key') ||  '-1';
+    const key = this.key ||  '-1';
 
     return get(scrollMap, key) || scrollMap.default;
   }


### PR DESCRIPTION
This is unnecessary for Ember >= v3.1