### PR TITLE
Fix documentation formatting around `scrollElement`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ historySupportMiddleware: true,
 ```
 
 This location type inherits from Ember's `HistoryLocation`.
-```
 
 
 ### Options


### PR DESCRIPTION
Just a small formatting fix that tripped me when I was looking for the `scrollElement` documentation.